### PR TITLE
Update image_processing.py

### DIFF
--- a/custom_components/codeproject_ai_object/image_processing.py
+++ b/custom_components/codeproject_ai_object/image_processing.py
@@ -344,7 +344,7 @@ class ObjectClassifyEntity(ImageProcessingEntity):
         # resize image if different then default
         if self._scale != DEAULT_SCALE:
             newsize = (self._image_width * self._scale, self._image_width * self._scale)
-            self._image.thumbnail(newsize, Image.ANTIALIAS)
+            self._image.thumbnail(newsize, Image.LANCZOS)
             self._image_width, self._image_height = self._image.size
             with io.BytesIO() as output:
                 self._image.save(output, format="JPEG")


### PR DESCRIPTION
The latest version of HomeAssistant ( Home Assistant 2023.8.1 - Supervisor 2023.07.1 - Operating System 10.4) ships with a new and updated version of Pillow which has deprecated the "ANTIALIAS" function. 
Without changing the code, the image processing script fails to acquire a snapshot from a source and process it.
The change has been tested and verified to be working correctly.

> 
Fix for ANTIALIAS function being removed in Pillow 10.0.0 (after being deprecated through many previous versions). The same function is now called through PIL.Image.LANCZOS or PIL.Image.Resampling.LANCZOS.